### PR TITLE
Only change decimals if there is one to get

### DIFF
--- a/src/com/flobi/floAuction/floAuction.java
+++ b/src/com/flobi/floAuction/floAuction.java
@@ -513,9 +513,11 @@ public class floAuction extends JavaPlugin {
     	// Make sure the decimalPlaces loaded correctly.
     	// Sometimes the econ loads after floAuction.
 	    if (!loadedDecimalFromVault && econ.isEnabled()) {
-	    	loadedDecimalFromVault = true;
-			decimalPlaces = econ.fractionalDigits();
-			config.set("decimal-places", decimalPlaces);
+			if(econ.fractionalDigits() >= 0) {
+				loadedDecimalFromVault = true;
+				decimalPlaces = econ.fractionalDigits();
+				config.set("decimal-places", decimalPlaces);
+			}
 			if (decimalPlaces < 1) {
 				decimalRegex = "^[0-9]{1,13}$";
 			} else if (decimalPlaces == 1) {


### PR DESCRIPTION
Fixes a bug that can occur where floauction rounds to 10s instead of 1s.
